### PR TITLE
Add `eventLayout` config option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
     "import/no-extraneous-dependencies": 2
   },
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 2018
   },
   "ignorePatterns": ["coverage/**/*", "commitlint.config.js"]
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install log4js @log4js-node/logfaces-http
 - `configContext` - function (optional) returning a global context object accessible to all appenders. Properties from configContext added as `p_` values in the logFaces event.
 - `hostname` - `string` (optional) - used to add the hostname `h` property to the logFaces event.
 - `agent` - `http.Agent | https.Agent` (optional) - used to configure the requests being sent out if needed.
-- `eventLayout` - `(LoggingEvent, LogFacesEvent) => LogFacesEvent` (optional) - allows more control and ability to modify and set the properties of the LogFacesEvent that will get sent to the server. Note: returning `null` or `undefined` will cause the event to be ignored and not logged. If you don't set `LogFacesEvent.m`, the default format for the message will be applied.
+- `eventLayout` - `(LoggingEvent, LogFacesEvent) => LogFacesEvent` (optional) - allows more control and ability to modify and set the properties of the LogFacesEvent that will get sent to the server. Note: returning `null` or `undefined` will cause the event to be ignored and not logged. If `LogFacesEvent.m` is nullish, the default format for the message will be applied.
 
 This appender will also pick up Logger context values from the events, and add them as `p_` values in the logFaces event. See the example below for more details. Note that Logger context may override the same properties defined in `configContext`.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm install log4js @log4js-node/logfaces-http
 - `configContext` - function (optional) returning a global context object accessible to all appenders. Properties from configContext added as `p_` values in the logFaces event.
 - `hostname` - `string` (optional) - used to add the hostname `h` property to the logFaces event.
 - `agent` - `http.Agent | https.Agent` (optional) - used to configure the requests being sent out if needed.
+- `eventLayout` - `(LoggingEvent, LogFacesEvent) => LogFacesEvent` (optional) - allows more control and ability to modify and set the properties of the LogFacesEvent that will get sent to the server. Note: returning `null` or `undefined` will cause the event to be ignored and not logged. If you don't set `LogFacesEvent.m`, the default format for the message will be applied.
 
 This appender will also pick up Logger context values from the events, and add them as `p_` values in the logFaces event. See the example below for more details. Note that Logger context may override the same properties defined in `configContext`.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-object-spread */
 /**
  * logFaces appender sends JSON formatted log events to logFaces receivers over HTTP.
  */
@@ -48,14 +49,17 @@ function logFacesAppender(config) {
 
   const { configContext } = config;
 
+  /**
+   * @param {import('log4js').LoggingEvent} event
+   */
   return function log(event) {
     // convert to logFaces compact json format
-    const lfsEvent = {
+    /** @type {import('../types').LogFacesEvent} */
+    let lfsEvent = {
       a: config.application || '', // application name
       t: event.startTime.getTime(), // time stamp
       p: event.level.levelStr, // level (priority)
       g: event.categoryName, // logger name
-      m: format(event.data), // message text
       h: config.hostname, // hostname
     };
 
@@ -87,7 +91,17 @@ function logFacesAppender(config) {
     Object.keys(event.context).forEach((key) => {
       lfsEvent[`p_${key}`] = event.context[key];
     });
-
+    if (config.eventLayout) {
+      lfsEvent = config.eventLayout(event, Object.assign({}, lfsEvent));
+      if (!lfsEvent) {
+        // no event object returned, consider the event ignored
+        return;
+      }
+    }
+    if (lfsEvent.m == null) {
+      // Add the default message on if not set
+      lfsEvent.m = format(event.data);
+    }
     // send to server
     sender.post('', lfsEvent).catch((error) => {
       if (error.response) {
@@ -103,6 +117,11 @@ function logFacesAppender(config) {
   };
 }
 
+/**
+ *
+ * @param {import('../types').LogFacesHTTPAppender} config
+ * @returns
+ */
 function configure(config) {
   return logFacesAppender(config);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,10 @@ function getErrorStack(logData) {
  * @param {import('../types').LogFacesHTTPAppender} config
  */
 function logFacesAppender(config) {
+  if (config.eventLayout && typeof config.eventLayout !== 'function') {
+    throw new TypeError('eventLayout must be a function');
+  }
+
   const sender = axios.create({
     baseURL: config.url,
     timeout: config.timeout || 5000,
@@ -93,6 +97,17 @@ function logFacesAppender(config) {
       lfsEvent = config.eventLayout(event, { ...lfsEvent });
       if (!lfsEvent) {
         // no event object returned, consider the event ignored
+        return;
+      }
+      if (
+        typeof lfsEvent !== 'object' ||
+        Array.isArray(lfsEvent) ||
+        Object.keys(lfsEvent).length < 3
+      ) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `log4js.logFaces-HTTP Appender eventLayout must be an object`
+        );
         return;
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,8 @@ function getErrorStack(logData) {
   return null;
 }
 
+const NUM_REQUIRED_PROPERTIES = 5;
+
 /**
  *
  * For HTTP (browsers or node.js) use the following configuration params:
@@ -102,11 +104,12 @@ function logFacesAppender(config) {
       if (
         typeof lfsEvent !== 'object' ||
         Array.isArray(lfsEvent) ||
-        Object.keys(lfsEvent).length < 3
+        // require at least the number of required properties ignoring `m`
+        Object.keys(lfsEvent).length < NUM_REQUIRED_PROPERTIES - 1
       ) {
         // eslint-disable-next-line no-console
         console.error(
-          `log4js.logFaces-HTTP Appender eventLayout must be an object`
+          `log4js.logFaces-HTTP Appender eventLayout() must return an object`
         );
         return;
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,6 @@
-/* eslint-disable prefer-object-spread */
 /**
  * logFaces appender sends JSON formatted log events to logFaces receivers over HTTP.
  */
-/* eslint global-require:0 */
 
 'use strict';
 
@@ -92,7 +90,7 @@ function logFacesAppender(config) {
       lfsEvent[`p_${key}`] = event.context[key];
     });
     if (config.eventLayout) {
-      lfsEvent = config.eventLayout(event, Object.assign({}, lfsEvent));
+      lfsEvent = config.eventLayout(event, { ...lfsEvent });
       if (!lfsEvent) {
         // no event object returned, consider the event ignored
         return;

--- a/test/tap/index-test.js
+++ b/test/tap/index-test.js
@@ -261,7 +261,7 @@ test('logFaces appender', (batch) => {
       },
     });
     const message =
-      'log4js.logFaces-HTTP Appender eventLayout must be an object';
+      'log4js.logFaces-HTTP Appender eventLayout() must return an object';
     ['array', 'string', 'object'].forEach((input) => {
       setup.logger.info(input);
       t.equal(setup.fakeConsole.msg, message);

--- a/test/tap/index-test.js
+++ b/test/tap/index-test.js
@@ -235,5 +235,35 @@ test('logFaces appender', (batch) => {
     t.end();
   });
 
+  batch.test('eventLayout should enable changing the results', (t) => {
+    const setup = setupLogging('myCategory', false, {
+      application: 'LFS-HTTP',
+      url: 'http://localhost/receivers/rx1',
+      eventLayout: (event, lfEvent) => {
+        if (event.data[0] === 'SUPER SECRET!') {
+          return undefined;
+        }
+        lfEvent.m = `test: ${event.data[0]}`;
+        lfEvent.r = 'steve';
+        return lfEvent;
+      },
+    });
+
+    setup.logger.info('Log event #1');
+    const event = setup.fakeAxios.args[1];
+    t.match(event, {
+      a: 'LFS-HTTP',
+      m: 'test: Log event #1',
+      g: 'myCategory',
+      p: 'INFO',
+      r: 'steve',
+    });
+
+    setup.fakeAxios.args = undefined;
+    setup.logger.info('SUPER SECRET!');
+    t.equal(setup.fakeAxios.args, undefined);
+    t.end();
+  });
+
   batch.end();
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,7 +53,7 @@ export interface LogFacesEvent {
   /** Message Content */
   m?: string;
   /** [Network Diagnostic Context](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/NDC.html) */
-  n?: unknown;
+  n?: string;
   /** Indication whether the event is a thrown exception */
   w?: boolean;
   /** Stack trace of thrown exceptions */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,6 +2,9 @@ import type { Agent as httpAgent } from 'http';
 import type { Agent as httpsAgent } from 'https';
 import type { LoggingEvent } from 'log4js';
 
+/** https://stackoverflow.com/a/53742583/13175138 */
+type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
 export interface LogFacesHTTPAppender {
   type: '@log4js-node/logfaces-http';
   /** logFaces receiver servlet URL */
@@ -34,7 +37,7 @@ export interface LogFacesHTTPAppender {
 export type LogFacesLayoutFunction = (
   loggingEvent: LoggingEvent,
   logFacesEvent: Omit<LogFacesEvent, 'm'>
-) => LogFacesEvent | undefined | null;
+) => PickPartial<LogFacesEvent, 'm'> | undefined | null;
 
 /** [Data model: Log events](http://www.moonlit-software.com/logfaces/downloads/logfaces-manual.pdf) */
 export interface LogFacesEvent {
@@ -51,7 +54,7 @@ export interface LogFacesEvent {
   /** Name of the thread originating the event */
   r?: string;
   /** Message Content */
-  m?: string;
+  m: string;
   /** [Network Diagnostic Context](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/NDC.html) */
   n?: string;
   /** Indication whether the event is a thrown exception */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,7 +24,10 @@ export interface LogFacesHTTPAppender {
   agent?: httpAgent | httpsAgent;
   /** Adjust the resulting logfacesEvent that is sent out.
    *
-   * Needs to return the new layout or undefined to ignore the event. */
+   * Needs to return the new layout or undefined to ignore the event.
+   *
+   * If `LogFacesEvent.m` is nullish: it will be populated with the default formatter
+   * */
   eventLayout?: LogFacesLayoutFunction;
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,6 @@
 import type { Agent as httpAgent } from 'http';
 import type { Agent as httpsAgent } from 'https';
+import type { LoggingEvent } from 'log4js';
 
 export interface LogFacesHTTPAppender {
   type: '@log4js-node/logfaces-http';
@@ -21,6 +22,51 @@ export interface LogFacesHTTPAppender {
    * Make sure you use the correct type base on your url
    */
   agent?: httpAgent | httpsAgent;
+  /** Adjust the resulting logfacesEvent that is sent out.
+   *
+   * Needs to return the new layout or undefined to ignore the event. */
+  eventLayout?: LogFacesLayoutFunction;
+}
+
+export type LogFacesLayoutFunction = (
+  loggingEvent: LoggingEvent,
+  logFacesEvent: Omit<LogFacesEvent, 'm'>
+) => LogFacesEvent | undefined | null;
+
+/** [Data model: Log events](http://www.moonlit-software.com/logfaces/downloads/logfaces-manual.pdf) */
+export interface LogFacesEvent {
+  /** Time stamp as specified by the source or server */
+  t?: number;
+  /** Sequence number, each event produced by logFaces has running sequence number */
+  q?: number;
+  /** Severity of event expressed in term of log4j levels */
+  p?: number | string;
+  /**  Name of the domain (or application) originating the event */
+  a?: string;
+  /** Name of the host originating the event */
+  h?: string;
+  /** Name of the logger (class, module, etc) originating the event */
+  g?: string;
+  /** Name of the thread originating the event */
+  r?: string;
+  /** Message Content */
+  m?: string;
+  /** [Network Diagnostic Context](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/NDC.html) */
+  n?: string;
+  /** Indication whether the event is a thrown exception */
+  w?: boolean;
+  /** Stack trace of thrown exceptions */
+  i?: string;
+  /** File name (of the source code location originating the event) */
+  f?: string;
+  /** Class name (of the source code location originating the event) */
+  c?: string;
+  /** Method name (of the source code location originating the event) */
+  e?: string;
+  /** Line number (of the source code location originating the event) */
+  l?: string | number;
+  /** MDC (Mapped Diagnostic Context) properties, p_XXX, where XXX is a property name */
+  [key: `p_${string}`]: string | number;
 }
 
 // Add the LogFacesHTTPAppender to the list of appenders in log4js for better type support

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,23 +36,21 @@ export type LogFacesLayoutFunction = (
 /** [Data model: Log events](http://www.moonlit-software.com/logfaces/downloads/logfaces-manual.pdf) */
 export interface LogFacesEvent {
   /** Time stamp as specified by the source or server */
-  t?: number;
-  /** Sequence number, each event produced by logFaces has running sequence number */
-  q?: number;
+  t: number;
   /** Severity of event expressed in term of log4j levels */
-  p?: number | string;
+  p: number | string;
   /**  Name of the domain (or application) originating the event */
-  a?: string;
+  a: string;
   /** Name of the host originating the event */
   h?: string;
   /** Name of the logger (class, module, etc) originating the event */
-  g?: string;
+  g: string;
   /** Name of the thread originating the event */
   r?: string;
   /** Message Content */
   m?: string;
   /** [Network Diagnostic Context](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/NDC.html) */
-  n?: string;
+  n?: unknown;
   /** Indication whether the event is a thrown exception */
   w?: boolean;
   /** Stack trace of thrown exceptions */


### PR DESCRIPTION
closes #1 

`eventLayout` lets you have fine-grained control over what you are sending to the logfaces server.

For example, if you want relative file path names being sent in `f` instead of absolute:

```js
log4js.configure({
  appenders: {
    logfaces: {
      type: "@log4js-node/logfaces-http",
      url: "http://lfs-server/logs",
      eventLayout: (event, lfEvent)=>{
        if(lfEvent.f){
          lfEvent.f = path.relative(path.resolve(), lfEvent.f);
        }
        return lfEvent;
      }
    },
  },
  categories: {
    default: { appenders: ["logfaces"], level: "info", enableCallStack: true },
  },
});
```

Or if you want to add commas between separate data entries:

```js
{
  eventLayout: (event, lfEvent)=>({
    ...lfEvent,
    m: event.data.map(item=>util.format(item)).join(', ');
  })
}
```