### PR TITLE
Errors send messages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,7 @@
 *.txt   text eol=lf
 *.xml   text eol=lf
 .husky/* text eol=lf
+*.yml    text eol=lf
 
 # Exclude the `.htaccess` file from GitHub's language statistics
 # https://github.com/github/linguist#using-gitattributes

--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ logger.info("some interesting log message");
 
 // global context variables can be modified anywhere in the app
 MDC.sessionID = 222;
-logger.error("something has gone wrong", new Error("exception message"));
+logger.error(new Error("exception message"), "something has gone wrong");
 ```
 
-This example will result in two log events being sent to `lfs-server`. Both events will have a `requestId` property with a value of `123`. First event will have `sessionID` of `111` and second `sessionID` of `222`. Also since `enableCallStack` is set, both events will include location details such as file name, function name and line number. Second event will have a stack trace of a trown error.
+This example will result in two log events being sent to `lfs-server`. Both events will have a `requestId` property with a value of `123`. The first event will have `sessionID` of `111` and second will have `sessionID` of `222`. Also since `enableCallStack` is set, both events will include location details such as file name, function name and line number.
+
+The second event will have a full stack trace of the `Error` object passed in.
+
+Without `enableCallStack`, the `Error` stack would still get logged, but not the file name, function name, and line number as those are parsed earlier.

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,12 +8,24 @@
 const util = require('util');
 const axios = require('axios');
 
+/**
+ *
+ * @param {any[]} logData
+ * @returns {string}
+ */
 function format(logData) {
-  // do not format error with stack, it is reported separetely
-  const filtered = logData.filter(
-    (item) => !(item instanceof Error && item.stack)
+  let foundError = false;
+  return util.format(
+    ...logData.map((item) => {
+      if (!foundError && item instanceof Error && item.stack) {
+        foundError = true;
+        // send only the base string for the first Error with a stack
+        // note: all errors on node have `stack` unless it's specifically deleted
+        return item.toString();
+      }
+      return item;
+    })
   );
-  return util.format(...filtered);
 }
 
 function getErrorStack(logData) {

--- a/test/tap/index-test.js
+++ b/test/tap/index-test.js
@@ -127,14 +127,17 @@ test('logFaces appender', (batch) => {
     const setup = setupLogging('stack-traces', false, {
       url: 'http://localhost/receivers/rx1',
     });
+    const error = new Error('something went wrong');
+    setup.logger.error(error, 'Oh no');
+    let [, event] = setup.fakeAxios.args;
+    t.equal(event.m, `${error.toString()} Oh no`);
+    const eventErrorLog = { w: true, i: error.stack };
+    t.match(event, eventErrorLog);
 
-    setup.logger.error('Oh no', new Error('something went wrong'));
-    const event = setup.fakeAxios.args[1];
-    t.equal(event.m, 'Oh no');
-    t.equal(event.w, true);
-    t.match(event.i, /Error: something went wrong/);
-    t.match(event.i, /at (Test.batch.test|Test.<anonymous>)/);
-
+    setup.logger.error('Oh no', error);
+    [, event] = setup.fakeAxios.args;
+    t.equal(event.m, `Oh no ${error.toString()}`);
+    t.match(event, eventErrorLog);
     t.end();
   });
 


### PR DESCRIPTION
I realized with my usage of logFaces-HTTP locally that having the Error objects not be included in the message by default was rather confusing.

The first error object will still be sent using `Error.toString` which looks like `Error: message`, whereas everything after that will end up serialized with it's full stack and all.